### PR TITLE
Remove wallet caching from the `LedgerWalletManager`

### DIFF
--- a/lib/src/wallet/constants.dart
+++ b/lib/src/wallet/constants.dart
@@ -1,0 +1,2 @@
+// Ledger
+const String ledgerWalletType = 'ledger';

--- a/lib/src/wallet/manager.dart
+++ b/lib/src/wallet/manager.dart
@@ -10,8 +10,6 @@ class LedgerWalletOptions implements WalletOptions {
 }
 
 class LedgerWalletManager implements WalletManager {
-  final _wallets = new Map<String, LedgerWallet>();
-
   final LedgerWalletOptions defaultWalletOptions =
       LedgerWalletOptions(confirmAddressByDefault: false);
 
@@ -35,14 +33,7 @@ class LedgerWalletManager implements WalletManager {
       throw Exception(
           "Unsupported wallet options ${walletOptions.runtimeType}.");
     }
-    
-    if (_wallets.containsKey(walletDefinition.walletId)) {
-      await _wallets.remove(walletDefinition.walletId)!.disconnect();
-    }
-    final wallet =
-        await LedgerWallet.connect(walletDefinition.walletId, walletOptions);
-    _wallets[walletDefinition.walletId] = wallet;
-    return wallet;
+    return await LedgerWallet.connect(walletDefinition.walletId, walletOptions);
   }
 
   @override

--- a/lib/src/wallet/wallet.dart
+++ b/lib/src/wallet/wallet.dart
@@ -1,4 +1,5 @@
 export 'account.dart';
+export 'constants.dart';
 export 'definition.dart';
 export 'ledger.dart';
 export 'manager.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: znn_ledger_dart
 description: Ledger Wallet for Zenon Dart SDK
 publish_to: none
-version: 0.0.2
+version: 0.0.3
 
 environment:
   sdk: '>=2.17.0 <3.0.0'


### PR DESCRIPTION
This PR removes the caching of wallets from the `LedgerWalletManager`.

It is better to leave the responsibility for disposing the `LedgerWallet` to the calling party.